### PR TITLE
stages/dnf: don't use configparser to write dnf.conf

### DIFF
--- a/stages/io.weldr.dnf
+++ b/stages/io.weldr.dnf
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-import configparser
 import json
 import os
 import subprocess
@@ -15,9 +14,21 @@ def main(tree, options):
     verbosity = options.get("verbosity", "info")
 
     with open("/tmp/dnf.conf", "w") as conf:
-        p = configparser.ConfigParser()
-        p.read_dict(repos)
-        p.write(conf)
+        for repoid, repo in repos.items():
+            conf.write(f"[{repoid}]\n")
+            for key, value in repo.items():
+                if type(value) == str:
+                    s = value
+                elif type(value) == list:
+                    s = " ".join(value)
+                elif type(value) == bool:
+                    s = "1" if value else "0"
+                elif type(value) == int:
+                    s = str(value)
+                else:
+                    print(f"unkown type for `{key}`: {value} ({type(value)})")
+                    return 1
+                conf.write(f"{key}={s}\n")
 
     script = f"""
         set -e


### PR DESCRIPTION
configparser writes strings with quotes and lists with enclosing
brackets, both of which may not appear in dnf.conf.

dnf.conf(5) defines the format loosely.