### PR TITLE
assemblers: resurrect io.weldr.targz

### DIFF
--- a/assemblers/io.weldr.targz
+++ b/assemblers/io.weldr.targz
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import json
+import subprocess
+import sys
+
+def main(tree, output_dir, options):
+    filename = options["filename"]
+
+    subprocess.run(["tar", "-czf", f"{output_dir}/{filename}", "-C", tree, "."], stdout=subprocess.DEVNULL, check=True)
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["output_dir"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
This was dropped in cebed27cd. However, a tar of a tree is useful in its
own right as an output format.