### PR TITLE
osbuild.py: add Assembler and Stage classes

### DIFF
--- a/osbuild
+++ b/osbuild
@@ -31,9 +31,6 @@ if __name__ == "__main__":
         pipeline = json.load(f)
     pipeline = osbuild.Pipeline(pipeline, args.objects)
 
-    print()
-    print(f"{RESET}{BOLD}Pipeline: {pipeline.id}{RESET}")
-
     try:
         pipeline.run(args.output_dir, interactive=True)
     except KeyboardInterrupt:


### PR DESCRIPTION
These are the concepts we already have, the only difference is that
now every stage/assembler may have a base, and the result of every
stage is saved in the object store.

Signed-off-by: Tom Gundersen <teg@jklm.no>