### PR TITLE
Simplify our grub2 handling

### DIFF
--- a/assemblers/io.weldr.qcow2
+++ b/assemblers/io.weldr.qcow2
@@ -61,18 +61,22 @@ def main(tree, output_dir, options):
         # Set up the partition table of the image
         partition_table = "label: mbr\nlabel-id: {partition_table_id}\nbootable, type=83"
         subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
+        r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
+        partition_table = json.loads(r.stdout)
+        partition = partition_table["partitiontable"]["partitions"][0]
+        partition_offset = partition["start"] * 512
+        partition_size = partition["size"] * 512
+
+        # Populate the first partition of the image with an ext4 fs and fill it with the contents of the
+        # tree we are operating on.
+        subprocess.run(["mkfs.ext4", "-d", tree, "-U", root_fs_uuid, "-E", f"offset={partition_offset}", image, f"{int(partition_size / 1024)}k"], input="y", encoding='utf-8', check=True)
 
         # Mount the created image as a loopback device
-        with loop_device(image, size) as loop:
-            # Populate the first partition of the image with an ext4 fs and fill it with the contents of the
-            # tree we are operating on.
-            subprocess.run(["mkfs.ext4", "-d", tree, "-U", root_fs_uuid, f"{loop}p1"], check=True)
-
-            # Install grub2 into the boot sector of the image
-            # It is unclear why chrooting into the image is required.
-            with mount(f"{loop}p1", mountpoint):
-                with mount_api(mountpoint):
-                    subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy", "--target", "i386-pc", loop], check=True)
+        with loop_device(image, size) as loop, \
+            mount(f"{loop}p1", mountpoint):
+            # Install grub2 into the boot sector of the image, and copy the grub2 imagise into /boot/grub2
+            with mount_api(mountpoint):
+                subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy", "--target", "i386-pc", loop], check=True)
 
         subprocess.run(["qemu-img", "convert", "-O" "qcow2", "-c", image, f"{output_dir}/{filename}"], check=True)
 

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -1,6 +1,6 @@
 {
   "name": "base-qcow2",
-  "base": "445c09ba71fd656aadcc2c1e84adb12dcc5fd193fcbdc386b63e2fc02e134e98",
+  "base": "d7f6aca0b9cf09833f70983c20ef3ac6e626152ee99901fc07f26cbf85c2bced",
   "assembler":
     {
       "name": "io.weldr.qcow2",

--- a/samples/base-with-grub2.json
+++ b/samples/base-with-grub2.json
@@ -6,8 +6,7 @@
       "name": "io.weldr.grub2",
       "systemResourcesFromEtc": ["/etc/grub.d"],
       "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-	"partition_table_id": "0xdeadbeef"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
       }
     }
   ]

--- a/stages/io.weldr.grub2
+++ b/stages/io.weldr.grub2
@@ -1,50 +1,11 @@
 #!/usr/bin/python3
 
-import contextlib
 import json
-import math
 import os
-import shutil
-import subprocess
 import sys
 import tempfile
 
-def tree_size(tree):
-    size = 0
-    for root, dirs, files in os.walk(tree):
-        for entry in files + dirs:
-            path = os.path.join(root, entry)
-            size += os.stat(path, follow_symlinks=False).st_size
-    return size
-
-@contextlib.contextmanager
-def mount(source, dest, *options):
-    os.makedirs(dest, 0o755, True)
-    subprocess.run(["mount", *options, source, dest], check=True)
-    try:
-        yield
-    finally:
-        subprocess.run(["umount", "-R", dest], check=True)
-
-@contextlib.contextmanager
-def mount_api(dest):
-    with mount("/dev", f"{dest}/dev", "-o", "rbind"), \
-         mount("/proc", f"{dest}/proc", "-o", "rbind"), \
-         mount("/sys", f"{dest}/sys", "-o", "rbind"), \
-         mount("none", f"{dest}/run", "-t", "tmpfs"):
-             yield
-
-@contextlib.contextmanager
-def loop_device(image):
-    r = subprocess.run(["losetup", "--show", "--find", image], stdout=subprocess.PIPE, encoding="utf-8", check=True)
-    loop = r.stdout.strip()
-    try:
-        yield loop
-    finally:
-        subprocess.run(["losetup", "-d", loop], check=True)
-
 def main(tree, options):
-    partition_table_id = options["partition_table_id"]
     root_fs_uuid = options["root_fs_uuid"]
 
     # Create the configuration file that determines how grub.cfg is generated.


### PR DESCRIPTION
Drop unused code, and reduce any loopback handling to the bare minimum.

The loopback handing for grub2 should be completely unnecessary, but we may need some help from the grub2 team to figure out the tooling. Note that grub2-install both installs the bootloader in the MBR and installs files into /boot, which we do not want.