### PR TITLE
move stages and assemblers into /usr/libexec/

### DIFF
--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -28,7 +28,7 @@ BOLD = "\033[1m"
 
 libdir = os.path.dirname(os.path.dirname(__file__))
 if not os.path.exists(f"{libdir}/stages"):
-    libdir = f"{sys.prefix}/lib/osbuild"
+    libdir = f"{sys.prefix}/libexec/osbuild"
 
 
 class StageFailed(Exception):


### PR DESCRIPTION
This change was requested during the package review process (related to #23):
https://bugzilla.redhat.com/show_bug.cgi?id=1731111