### PR TITLE
Clean up libdir

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init
+disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments
 max-line-length=120
 
 [TYPECHECK]

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument("--objects", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild/objects",
                         help="the directory where intermediary os trees are stored")
+    parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
+                        help="the directory containing stages, assemblers, and the osbuild library")
     requiredNamed = parser.add_argument_group('required named arguments')
     requiredNamed.add_argument("-o", "--output", dest="output_dir", metavar="DIRECTORY", type=os.path.abspath,
                                help="provide the empty DIRECTORY as output argument to the last stage", required=True)
@@ -26,7 +28,7 @@ def main():
         pipeline = osbuild.load(json.load(f))
 
     try:
-        pipeline.run(args.output_dir, args.objects, interactive=True)
+        pipeline.run(args.output_dir, args.objects, interactive=True, libdir=args.libdir)
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 $script = <<-SCRIPT
-sudo dnf install qemu-system-x86 /vagrant/osbuild*.rpm -y
+sudo dnf install qemu-system-x86 /vagrant/*.noarch.rpm -y
 SCRIPT
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
See individual commits.

This fixes the vagrant test while still making it possible to run from source, albeit we need to pass `--libdir .` now. That makes more sense to me than guessing based on checking if `stages` is a directory.