### PR TITLE
travis: move to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-dist: xenial   # required for Python >= 3.7
+dist: bionic
 language: python
 python:
   - "3.7"
 install:
   - pip install pylint
-# command to run tests
-script: pylint osbuild assemblers/* stages/*
+jobs:
+  include:
+    - name: pylint
+      script: pylint osbuild assemblers/* stages/*


### PR DESCRIPTION
Let's always use the latest available Ubuntu release for our CI, we
are interested in potentially building old images, and using old
images as bulid images, but having an old distro as host is not
necessarily an aim. If we want to test with a greater diversity of
distros (which we do), we should do that in VM's, this should just
be for the simple/quick case.

Also restructure a bit to allow for more (named) tests.

Signed-off-by: Tom Gundersen <teg@jklm.no>